### PR TITLE
converting the spec to a script

### DIFF
--- a/BddIdeas.Core/BddIdeas.Core.csproj
+++ b/BddIdeas.Core/BddIdeas.Core.csproj
@@ -45,6 +45,9 @@
     <Compile Include="Spec.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(ProjectDir)$(OutDir)BddIdeas.Core.dll" "$(SolutionDir)Scripts\bin\"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Scripts/bdd.csx
+++ b/Scripts/bdd.csx
@@ -1,0 +1,8 @@
+#r "BddIdeas.Core.dll"
+using BddIdeas.Core;
+
+public static Idea idea = new Idea();
+
+public static Action<object, Action> describe = idea.Describe;
+public static Action<string, Action> it = idea.It;
+public static Action<Action> before = idea.Before;

--- a/Scripts/readme.md
+++ b/Scripts/readme.md
@@ -1,0 +1,2 @@
+This requires scriptcs 
+http://scriptcs.net/

--- a/Scripts/sample_spec.csx
+++ b/Scripts/sample_spec.csx
@@ -1,0 +1,51 @@
+#load "bdd.csx"
+
+#r "Microsoft.VisualStudio.QualityTools.UnitTestFramework"
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+describe(typeof (Idea), () =>
+{
+			var a = 0;
+			before(() => a = 10);
+
+			it("executes it blocks", () =>
+			{
+				Assert.AreEqual(0, 0);
+			});
+
+			it("gracefully handles exceptions", () =>
+			{
+				throw new Exception("This was completely intentional.");
+			});
+
+			describe("nested contexts", () =>
+			{
+          before(() => a = 1);
+
+          it("handles them", () =>
+          {
+          	Assert.IsTrue(true);
+          });
+
+          it("handles before blocks correctly", () =>
+          {
+          	Assert.AreEqual(a, 1);
+          });
+			});
+
+			describe("intentional failures", () =>
+			{
+  				it("does what testing frameworks do", () =>
+  				{
+  					Assert.AreEqual(4, 5);
+  				});
+			});
+
+			describe("other neat features", () =>
+			{
+  				idea.Pending("specs are allowed.", () =>
+  				{
+  					Assert.Fail("This won't be executed");
+  				});
+			});
+});


### PR DESCRIPTION
This is the beginning of being able to write a spec without all of the extra ceremony.
- [x] a compilable spec with ambient functions
- [ ] loading the output of the script into an actual runner 
- [ ] using [hosted scriptcs ](https://www.nuget.org/packages/ScriptCs.Hosting/) instead of doing it from the command line
